### PR TITLE
Add Vicidial Bootstrap theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# hamzagpt
+# HamzaGPT Repository
+
+Ce dépôt contient un exemple de thème Bootstrap pour Vicidial.
+
+Voir le dossier `vicidial_theme` pour l'ensemble des fichiers HTML, CSS et JS.

--- a/vicidial_theme/README.md
+++ b/vicidial_theme/README.md
@@ -1,0 +1,17 @@
+# Vicidial Bootstrap Theme
+
+Ce thème fournit des interfaces modernes pour Vicidial à l'aide de Bootstrap 5.
+
+## Installation
+
+1. Copier le dossier `vicidial_theme` dans `/var/www/html/vicidial/`.
+2. Ouvrir `login.html` pour se connecter ou `index.html` pour accéder au tableau de bord admin.
+3. Les fichiers `css/theme.css` (clair) et `css/theme-dark.css` (sombre) gèrent les styles. Le bouton "Mode sombre" active/désactive le thème sombre et mémorise le choix via `localStorage`.
+4. Les pages principales :
+   - `index.html` : tableau de bord admin
+   - `campaigns.html` : gestion des campagnes
+   - `users.html` : liste des utilisateurs
+   - `reports.html` : rapports
+   - `agent.html` : interface agent
+
+Aucun backend n'est inclus. Les pages sont statiques et servent de base pour l'intégration dans Vicidial.

--- a/vicidial_theme/agent.html
+++ b/vicidial_theme/agent.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Interface Agent</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link id="theme-dark" href="css/theme-dark.css" rel="stylesheet" disabled>
+    <link href="css/theme.css" rel="stylesheet">
+    <style>
+        .lead-info { max-height: 150px; overflow-y: auto; }
+        .script-zone { max-height: 200px; overflow-y: auto; }
+    </style>
+</head>
+<body>
+<nav class="topbar d-flex justify-content-between align-items-center p-2">
+    <h4 class="mb-0">Agent</h4>
+    <button id="themeToggle" class="btn btn-sm btn-secondary">Mode sombre</button>
+</nav>
+<div class="container-fluid p-4">
+    <div class="row">
+        <div class="col-md-4 mb-3">
+            <div class="card">
+                <div class="card-body">
+                    <h5>Lead</h5>
+                    <div class="lead-info">
+                        <p>Nom: <strong>Durand</strong></p>
+                        <p>Prénom: <strong>Paul</strong></p>
+                        <p>Téléphone: <strong>0102030405</strong></p>
+                        <p>Adresse: <strong>1 rue Exemple, Paris</strong></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-8 mb-3">
+            <div class="card">
+                <div class="card-body">
+                    <h5>Script d'appel</h5>
+                    <div class="script-zone">
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="call-panel mb-3">
+        <button class="btn btn-success">Appeler</button>
+        <button class="btn btn-danger">Raccrocher</button>
+        <button class="btn btn-warning">Pause</button>
+    </div>
+    <div class="mb-3">
+        <h5>Dispositions</h5>
+        <button class="btn btn-outline-primary me-2">Vendu</button>
+        <button class="btn btn-outline-secondary me-2">Rappel</button>
+        <button class="btn btn-outline-danger">Refus</button>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/vicidial_theme/campaigns.html
+++ b/vicidial_theme/campaigns.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Campagnes</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link id="theme-dark" href="css/theme-dark.css" rel="stylesheet" disabled>
+    <link href="css/theme.css" rel="stylesheet">
+</head>
+<body>
+<div class="d-flex">
+    <nav class="sidebar p-3 text-white" id="sidebar">
+        <h4 class="text-center">Vicidial</h4>
+        <ul class="nav flex-column">
+            <li class="nav-item"><a class="nav-link text-white" href="index.html">Dashboard</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="campaigns.html">Campagnes</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="users.html">Utilisateurs</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="reports.html">Rapports</a></li>
+        </ul>
+    </nav>
+
+    <div class="flex-grow-1">
+        <nav class="topbar d-flex justify-content-between align-items-center p-2">
+            <button class="btn btn-outline-secondary d-md-none" id="sidebarToggle">☰</button>
+            <div class="d-flex align-items-center">
+                <span class="me-3">Admin</span>
+                <button id="themeToggle" class="btn btn-sm btn-secondary">Mode sombre</button>
+            </div>
+        </nav>
+
+        <div class="container-fluid p-4">
+            <h2>Campagnes</h2>
+            <table class="table table-striped">
+                <thead>
+                    <tr><th>Nom</th><th>Statut</th><th>Date</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td>Campagne 1</td><td>Active</td><td>2023-01-10</td></tr>
+                    <tr><td>Campagne 2</td><td>Pause</td><td>2023-02-15</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/vicidial_theme/css/theme-dark.css
+++ b/vicidial_theme/css/theme-dark.css
@@ -1,0 +1,23 @@
+/* Dark theme styles */
+body {
+    background-color: #212529;
+    color: #f8f9fa;
+}
+
+.sidebar {
+    background-color: #000;
+}
+
+.sidebar a {
+    color: #adb5bd;
+}
+
+.topbar {
+    background-color: #343a40;
+    border-bottom: 1px solid #495057;
+}
+
+.card {
+    background-color: #343a40;
+    color: #f8f9fa;
+}

--- a/vicidial_theme/css/theme.css
+++ b/vicidial_theme/css/theme.css
@@ -1,0 +1,27 @@
+/* Light theme styles for Vicidial Bootstrap theme */
+body {
+    background-color: #f8f9fa;
+    color: #212529;
+}
+
+.sidebar {
+    min-height: 100vh;
+    background-color: #343a40;
+}
+
+.sidebar a {
+    color: #fff;
+}
+
+.topbar {
+    background-color: #fff;
+    border-bottom: 1px solid #dee2e6;
+}
+
+.card {
+    margin-bottom: 1rem;
+}
+
+.call-panel .btn {
+    margin-right: 0.5rem;
+}

--- a/vicidial_theme/index.html
+++ b/vicidial_theme/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Vicidial Admin</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link id="theme-dark" href="css/theme-dark.css" rel="stylesheet" disabled>
+    <link href="css/theme.css" rel="stylesheet">
+</head>
+<body>
+<div class="d-flex">
+    <nav class="sidebar p-3 text-white" id="sidebar">
+        <h4 class="text-center">Vicidial</h4>
+        <ul class="nav flex-column">
+            <li class="nav-item"><a class="nav-link text-white" href="index.html">Dashboard</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="campaigns.html">Campagnes</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="users.html">Utilisateurs</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="reports.html">Rapports</a></li>
+        </ul>
+    </nav>
+
+    <div class="flex-grow-1">
+        <nav class="topbar d-flex justify-content-between align-items-center p-2">
+            <button class="btn btn-outline-secondary d-md-none" id="sidebarToggle">☰</button>
+            <div class="d-flex align-items-center">
+                <span class="me-3">Admin</span>
+                <button id="themeToggle" class="btn btn-sm btn-secondary">Mode sombre</button>
+            </div>
+        </nav>
+
+        <div class="container-fluid p-4">
+            <div class="row">
+                <div class="col-md-3">
+                    <div class="card text-center">
+                        <div class="card-body">
+                            <h5 class="card-title">Agents actifs</h5>
+                            <p class="card-text">15</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="card text-center">
+                        <div class="card-body">
+                            <h5 class="card-title">Appels</h5>
+                            <p class="card-text">320</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="card text-center">
+                        <div class="card-body">
+                            <h5 class="card-title">Campagnes</h5>
+                            <p class="card-text">8</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="card text-center">
+                        <div class="card-body">
+                            <h5 class="card-title">Taux de décroché</h5>
+                            <p class="card-text">75%</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/vicidial_theme/js/script.js
+++ b/vicidial_theme/js/script.js
@@ -1,0 +1,30 @@
+// Sidebar toggle for mobile
+const sidebarToggle = document.getElementById('sidebarToggle');
+if (sidebarToggle) {
+    sidebarToggle.addEventListener('click', () => {
+        document.body.classList.toggle('sidebar-collapsed');
+    });
+}
+
+// Dark mode toggle
+const themeToggle = document.getElementById('themeToggle');
+if (themeToggle) {
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'dark') {
+        setDarkMode(true);
+    }
+    themeToggle.addEventListener('click', () => {
+        const dark = document.body.classList.toggle('dark-mode');
+        setDarkMode(dark);
+    });
+}
+
+function setDarkMode(enable) {
+    if (enable) {
+        document.getElementById('theme-dark').disabled = false;
+        localStorage.setItem('theme', 'dark');
+    } else {
+        document.getElementById('theme-dark').disabled = true;
+        localStorage.setItem('theme', 'light');
+    }
+}

--- a/vicidial_theme/login.html
+++ b/vicidial_theme/login.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Vicidial - Connexion</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link id="theme-dark" href="css/theme-dark.css" rel="stylesheet" disabled>
+    <link href="css/theme.css" rel="stylesheet">
+</head>
+<body class="d-flex align-items-center justify-content-center" style="height:100vh;">
+    <div class="card p-4" style="min-width:300px;">
+        <h1 class="h4 mb-3 text-center">Connexion</h1>
+        <form>
+            <div class="mb-3">
+                <label for="email" class="form-label">Email</label>
+                <input type="email" class="form-control" id="email" required>
+            </div>
+            <div class="mb-3">
+                <label for="password" class="form-label">Mot de passe</label>
+                <input type="password" class="form-control" id="password" required>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Se connecter</button>
+        </form>
+        <div class="text-center mt-3">
+            <button id="themeToggle" class="btn btn-sm btn-secondary">Mode sombre</button>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="js/script.js"></script>
+</body>
+</html>

--- a/vicidial_theme/reports.html
+++ b/vicidial_theme/reports.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Rapports</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link id="theme-dark" href="css/theme-dark.css" rel="stylesheet" disabled>
+    <link href="css/theme.css" rel="stylesheet">
+</head>
+<body>
+<div class="d-flex">
+    <nav class="sidebar p-3 text-white" id="sidebar">
+        <h4 class="text-center">Vicidial</h4>
+        <ul class="nav flex-column">
+            <li class="nav-item"><a class="nav-link text-white" href="index.html">Dashboard</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="campaigns.html">Campagnes</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="users.html">Utilisateurs</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="reports.html">Rapports</a></li>
+        </ul>
+    </nav>
+
+    <div class="flex-grow-1">
+        <nav class="topbar d-flex justify-content-between align-items-center p-2">
+            <button class="btn btn-outline-secondary d-md-none" id="sidebarToggle">☰</button>
+            <div class="d-flex align-items-center">
+                <span class="me-3">Admin</span>
+                <button id="themeToggle" class="btn btn-sm btn-secondary">Mode sombre</button>
+            </div>
+        </nav>
+
+        <div class="container-fluid p-4">
+            <h2>Rapports</h2>
+            <table class="table table-striped">
+                <thead>
+                    <tr><th>Date</th><th>Campagne</th><th>Appels</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td>2023-07-20</td><td>Campagne 1</td><td>150</td></tr>
+                    <tr><td>2023-07-21</td><td>Campagne 2</td><td>170</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/vicidial_theme/users.html
+++ b/vicidial_theme/users.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Utilisateurs</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link id="theme-dark" href="css/theme-dark.css" rel="stylesheet" disabled>
+    <link href="css/theme.css" rel="stylesheet">
+</head>
+<body>
+<div class="d-flex">
+    <nav class="sidebar p-3 text-white" id="sidebar">
+        <h4 class="text-center">Vicidial</h4>
+        <ul class="nav flex-column">
+            <li class="nav-item"><a class="nav-link text-white" href="index.html">Dashboard</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="campaigns.html">Campagnes</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="users.html">Utilisateurs</a></li>
+            <li class="nav-item"><a class="nav-link text-white" href="reports.html">Rapports</a></li>
+        </ul>
+    </nav>
+
+    <div class="flex-grow-1">
+        <nav class="topbar d-flex justify-content-between align-items-center p-2">
+            <button class="btn btn-outline-secondary d-md-none" id="sidebarToggle">☰</button>
+            <div class="d-flex align-items-center">
+                <span class="me-3">Admin</span>
+                <button id="themeToggle" class="btn btn-sm btn-secondary">Mode sombre</button>
+            </div>
+        </nav>
+
+        <div class="container-fluid p-4">
+            <h2>Utilisateurs</h2>
+            <table class="table table-striped">
+                <thead>
+                    <tr><th>Nom</th><th>Email</th><th>Rôle</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td>Jean Dupont</td><td>jean@example.com</td><td>Agent</td></tr>
+                    <tr><td>Marie Martin</td><td>marie@example.com</td><td>Admin</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="js/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Bootstrap theme for Vicidial with admin and agent interfaces
- include light and dark styles and JS toggle
- provide HTML pages for admin, agent, campaigns, users, reports, login
- add README with installation notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6880d93e1670832d9693cfd33ebe732e